### PR TITLE
User: Don't use 'is not' for checking against empty string

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -151,7 +151,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
         path = reverse_lazy('user-activate', request=request)
         link = "{}?key={}".format(path, self.activation_key)
-        if self.username is not '':
+        if self.username:
             name = self.username
         else:
             name = self.email
@@ -169,7 +169,7 @@ class User(AbstractBaseUser, PermissionsMixin):
                             request=request
                             )
         link = "{}?key={}".format(path, self.reset_password_key)
-        if self.username is not '':
+        if self.username:
             name = self.username
         else:
             name = self.email


### PR DESCRIPTION
An empty string is considered False in Python. 
'is not' is checking whether the object is the same.